### PR TITLE
added console write for error on fetching github data

### DIFF
--- a/AutoTrust/DataHandling/APIs/GithubPullRequestsSearch.cs
+++ b/AutoTrust/DataHandling/APIs/GithubPullRequestsSearch.cs
@@ -20,12 +20,6 @@ public class GithubPullRequestsSearch {
   public static async Task<GithubPullRequestsSearch?> GetGithubPullRequestsSearch(HttpClient httpClient, string? githubToken, string authorAndProject, string url, bool isDiagnostic) => await DataHandler.FetchGithubData<GithubPullRequestsSearch>(httpClient, githubToken, url, authorAndProject, isDiagnostic,
      $"Found pull request data for {authorAndProject} from {url}");
 
-  // public static string GetOpenGithubPullRequestsUrl(string authorAndProject) => "https://api.github.com/search/issues?q=repo:" + authorAndProject + "+type:pr+state:open&per_page=1";
-  public static string GetOpenGithubPullRequestsUrl(string authorAndProject) => "https://api.github.com/repos/" + authorAndProject + "/pulls?per_page=1&state=open";
-
-  // public static string GetClosedGithubPullRequestsUrl(string authorAndProject) => "https://api.github.com/search/issues?q=repo:" + authorAndProject + "+type:pr+state:closed&per_page=1";
-  public static string GetClosedGithubPullRequestsUrl(string authorAndProject) => "https://api.github.com/repos/" + authorAndProject + "/pulls?per_page=1&state=closed";
-
   public static string GetUpdatedGithubPullRequestsUrl(string authorAndProject, string lastUpdateTime) => $"https://api.github.com/search/issues?q=repo:{authorAndProject}+type:pr+state:open+updated:>{lastUpdateTime}&per_page=1";
 
 }

--- a/AutoTrust/DataHandling/DataHandler.cs
+++ b/AutoTrust/DataHandling/DataHandler.cs
@@ -74,8 +74,10 @@ public class DataHandler {
             Console.WriteLine(diagnosticText);
           }
           if (response.IsSuccessStatusCode) {
-
             return await response.Content.ReadFromJsonAsync<T>();
+          }
+          else {
+            Console.WriteLine($"Error: An HTTP error occurred for {authorAndProject} from {url}: {response.StatusCode}");
           }
         }
       }


### PR DESCRIPTION
This has nothing to do with bug_fixes, but removed some unused code and added console writeline when fetchgithubdata fails. For some reason the "catch" used in FetchGithubData do not throw an error when !response.IsSuccessStatusCode. However, with the current solution, we also throw error when we do not find readme: 
![image](https://user-images.githubusercontent.com/56224077/232324287-0af2d1df-be70-4a15-b53c-26c28e770901.png)
